### PR TITLE
Refactor: refactor unit tests, adds Travis CI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 #razorframe  
 **Version**  
-[![npm version](https://badge.fury.io/js/razorframe.svg)](https://badge.fury.io/js/razorframe)  
+[![npm version](https://badge.fury.io/js/razorframe.svg)](https://badge.fury.io/js/razorframe) 
+![Build Status](https://travis-ci.org/team-emt/razorframe.svg?branch=master) 
+  
 ###*Empowering scalable, real-time web apps in Node.js*  
 
 ###Visit us at: [http://www.razorfra.me](http://www.razorfra.me)  

--- a/test/js/integration.js
+++ b/test/js/integration.js
@@ -1,13 +1,24 @@
-const chai = require('chai');
-const mocha = require('mocha');
-// const should = chai.should();
 const { expect } = require('chai');
 const { rz } = require('../../lib/Razorframe.js');
 
+////////   SERVER SET-UP   //////////////
+const express = require('express');
+const app = express();
+const http = require('http').Server(app);
+const rzConfig = {
+  port: process.env.PORT || 3000,
+  cluster: false
+};
+const dbConfig = {
+  write: null,
+  show: null,
+  update: null,
+  delete: null,
+};
 const io = require('socket.io-client');
+/////////////////////////////////////////
 
 describe("echo", function () {
-
   let server,
     options = {
       transports: ['websocket'],
@@ -16,7 +27,6 @@ describe("echo", function () {
 
   beforeEach(function (done) {
     // start the server
-    const {http, rzConfig, dbConfig } = require('./app.js');
     server = rz.init(http, rzConfig, dbConfig);
     done();
   });
@@ -25,23 +35,12 @@ describe("echo", function () {
     let client = io.connect("http://localhost:3000", options);
 
     client.on('msgBack', (message) => {
-      // message.should.equal('heyo');
       expect(message).to.equal('heyo');
       client.disconnect();
       done();
     });
 
     client.emit('msgSent', { contents: 'heyo', eventOut: 'msgBack' });
-
-    // client.once("connection", function () {
-    //   client.once("msgSent", function (message) {
-    //     message.should.equal("echo");
-
-    //     client.disconnect();
-    //     done();
-    //   });
-
-    //   client.emit("msgSent", "Hello World");
-    // });
   });
+
 });

--- a/test/js/unit.js
+++ b/test/js/unit.js
@@ -1,42 +1,41 @@
 const LinkedList = require('../../lib/LinkedList');
 const { rz } = require('../../lib/Razorframe');
-const { expect, assert } = require('chai');
-const mocha = require('mocha');
+const { expect } = require('chai');
 
-describe('messaging queue unit tests', () => {
+describe('messaging queue unit tests', function() {
 
-  describe('#Linked List tests', () => {
+  describe('#Linked List tests', function() {
     let ll = new LinkedList();
 
-    it('Linked List should contain valid push / pop methods', () => {
+    it('Linked List should contain valid push / pop methods', function() {
       ll.push(5);
       ll.push(10);
       expect(ll.pop()).to.equal(5);
       expect(ll.pop()).to.equal(10);
     });
 
-    it('Linked List assigns head properly', () => {
+    it('Linked List assigns head properly', function() {
       ll.push(5);
       ll.push(10);
       expect(ll.head.value).to.equal(5);
     });
 
-    it('Linked List assigns tail properly', () => {
+    it('Linked List assigns tail properly', function() {
       expect(ll.tail.value).to.equal(10);
     });
   });
 
-  describe('#Messaging queue tests', () => {
+  describe('#Messaging queue tests', function() {
 
-    it('Razorframe should be instantiated', () => {
+    it('Razorframe should be instantiated', function() {
       expect(rz.razorframe).to.not.equal(undefined);
     });
 
-    it('Should be empty', () => {
+    it('Should be empty', function() {
       expect(rz.razorframe.storage.length).to.equal(0);
     });
 
-    it('should enqueue and dequeue messages', () => {
+    it('should enqueue and dequeue messages', function() {
       let obj1 = { contents: 'test1', eventOut: 'test', action: 'write' };
       let obj2 = { contents: 'test2', eventOut: 'test', action: 'write' };
       rz.razorframe.enqueue(obj1);
@@ -50,18 +49,18 @@ describe('messaging queue unit tests', () => {
     });
   });
 
-  describe('#Testing EventEmitter communication for function chains', () => {
-    it('Enqueue should emit an enq event', (done) => {
+  describe('#Testing EventEmitter communication for function chains', function() {
+    it('Enqueue should emit an enq event', function(done) {
       let obj1 = { contents: 'test1', eventOut: 'test', action: 'write' };
-      rz.razorframe.notification.on('enq', (data) => {
+      rz.razorframe.notification.on('enq', function(data) {
         expect(data).to.equal(1);
         done();
       });
       rz.razorframe.enqueue(obj1);
     });
 
-    it('Dequeue should emit a deq event', (done) => {
-      rz.razorframe.notification.on('deq', (data) => {
+    it('Dequeue should emit a deq event', function(done) {
+      rz.razorframe.notification.on('deq', function(data) {
         expect(data.contents).to.equal('test1');
         done();
       });
@@ -70,4 +69,3 @@ describe('messaging queue unit tests', () => {
   });
 
 });
-


### PR DESCRIPTION
I refactored the unit tests to not use arrow functions and to set up refactoring some of them with promises to see if we can get them running sequentially without interfering with each other.