### PR TITLE
Changed hosted Redis reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ npm i --save razorframe
 ##How to Use
 ###<a name="server"></a>Server-side module:  
 
-###NOTE: 
+**Note:**
 We have removed the hosted Redis server originally provided during initial rollout.  In order to leverage concurrency with razorframe and ensure server -> client communication, be sure to instantiate a local or hosted Redis server for your application.  
 
 You can store your Redis reference in an environment variable, or fall back to a locally hosted instance (see below):
@@ -52,21 +52,21 @@ You can store your Redis reference in an environment variable, or fall back to a
 const REDIS_URL = process.env.REDIS_URL || { host: 'localhost', port: 6379 }
 ```
 
-1) Require razorframe.  
-2) Specify rzConfig object to set up server processes by declaring:
+**(1) Require razorframe**  
+**(2) Specify rzConfig object to set up server processes by declaring:**
 
 * `rzConfig.port`: port where your server is listening.  
 * `rzConfig.cluster`: true or false depending on whether you want to enable Node clusters.  
 (Even though our config automatically accounts for 1 process if not specified, you'll still get better performance if you turn off Node clusters if you know you won't be using more than one CPU.)  
 
-3) Specify dbConfig object to define your back-end callbacks. 
+**(3) Specify ```dbConfig``` object to define your back-end callbacks** 
 
 * `dbConfig.write`: 'create' function for database. 
 * `dbConfig.show`: 'read' function for database.  
 * `dbConfig.update`: 'update' function for database.  
 * `dbConfig.delete`: 'delete' function for databse.   
  
-4) Initialize razorframe while passing in http (for your server) and the configurations.
+**(4) Initialize razorframe while passing in http (for your server) and the configurations**
 
 ```javascript
 const rz = require('razorframe');

--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ $ npm i --save razorframe
 
 ##How to Use
 ###<a name="server"></a>Server-side module:  
-NOTE: We have provided a hosted Redis server inside Razorframe to act as a linking adapter for multiple Node workers.  This is intended for development prototyping for the time being.  As we move into production projects, we will provide a way for you to pass in your own Redis instance for this purpose.  
+
+###NOTE: 
+We have removed the hosted Redis server originally provided during initial rollout.  In order to leverage concurrency with razorframe and ensure server -> client communication, be sure to instantiate a local or hosted Redis server for your application.  
+
+You can store your Redis reference in an environment variable, or fall back to a locally hosted instance (see below):
+
+```javascript
+const REDIS_URL = process.env.REDIS_URL || { host: 'localhost', port: 6379 }
+```
 
 1) Require razorframe.  
 2) Specify rzConfig object to set up server processes by declaring:

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ $ npm i --save razorframe
 ```
 
 ##How to Use
-###<a name="server"></a>Server-side module:  
 
-**Note:**
+###Hosted Redis server:  
 We have removed the hosted Redis server originally provided during initial rollout.  In order to leverage concurrency with razorframe and ensure server -> client communication, be sure to instantiate a local or hosted Redis server for your application.  
 
 You can store your Redis reference in an environment variable, or fall back to a locally hosted instance (see below):
@@ -52,8 +51,11 @@ You can store your Redis reference in an environment variable, or fall back to a
 const REDIS_URL = process.env.REDIS_URL || { host: 'localhost', port: 6379 }
 ```
 
+
+###<a name="server"></a>Server-side module:  
+
 **(1) Require razorframe**  
-**(2) Specify rzConfig object to set up server processes by declaring:**
+**(2) Specify ```rzConfig``` object to set up server processes by declaring:**
 
 * `rzConfig.port`: port where your server is listening.  
 * `rzConfig.cluster`: true or false depending on whether you want to enable Node clusters.  

--- a/lib/Razorframe.js
+++ b/lib/Razorframe.js
@@ -8,7 +8,7 @@ let io;
 
 const redis = require('redis');
 const redisAdapter = require('socket.io-redis');
-const REDIS_URL = 'redis://rediscloud:2dfnKjdph4GyDuO3@redis-19519.c11.us-east-1-2.ec2.cloud.redislabs.com:19519';
+const REDIS_URL = process.env.REDIS_URL || { host: 'localhost', port: 6379 };
 
 
 /** @constructs Razorframe


### PR DESCRIPTION
Removed hosted server; provide documentation and updated variable references in source code to allow for future developers to instantiate their own Redis servers